### PR TITLE
Add PDF export options

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@ import logging
 import traceback
 import re  # para expresiones regulares
 from flask import Flask, render_template, request, redirect, url_for, flash, jsonify, abort, send_file, send_from_directory
+from weasyprint import HTML
 from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy import func
 from datetime import datetime, timedelta, date, time
@@ -1324,10 +1325,12 @@ def informe_mensual():
         
         return resultado
 
+    pdf_requested = False
     # Para peticiones GET con parámetros
     if request.method == 'GET' and request.args.get('mes') and request.args.get('anio'):
         mes = int(request.args.get('mes'))
         anio = int(request.args.get('anio'))
+        pdf_requested = 'pdf' in request.args
         
         # Obtener el primer y último día del mes
         primer_dia = date(anio, mes, 1)
@@ -1336,6 +1339,7 @@ def informe_mensual():
     elif request.method == 'POST':
         mes = int(request.form['mes'])
         anio = int(request.form['anio'])
+        pdf_requested = 'pdf' in request.form
         
         # Obtener el primer y último día del mes
         primer_dia = date(anio, mes, 1)
@@ -1889,9 +1893,9 @@ def informe_mensual():
     
     # The morning/afternoon classification logic has been removed
     
-    return render_template('informes/mensual_resultado.html', 
-                          mes=mes, 
-                          anio=anio, 
+    html = render_template('informes/mensual_resultado.html',
+                          mes=mes,
+                          anio=anio,
                           clases_realizadas=clases_realizadas,
                           clases_no_registradas=clases_no_registradas,
                           conteo_no_registradas=conteo_no_registradas,
@@ -1903,6 +1907,11 @@ def informe_mensual():
                           total_alumnos=total_alumnos,
                           total_retrasos=total_retrasos,
                           total_pagos=total_pagos)
+
+    if pdf_requested:
+        pdf = HTML(string=html, base_url=request.base_url).write_pdf()
+        return send_file(io.BytesIO(pdf), download_name=f"informe_mensual_{mes}_{anio}.pdf", mimetype='application/pdf')
+    return html
 
 # Rutas para la importación de Excel
 
@@ -4949,6 +4958,7 @@ def metricas_profesor(profesor_id):
         
         # Verificar si se debe mostrar el modo de depuración
         debug_mode = request.args.get('debug', type=bool, default=False)
+        pdf_requested = 'pdf' in request.args
         
         # Obtener parámetros de filtro opcional
         tipo_clase = request.args.get('tipo_clase', default=None)
@@ -5069,9 +5079,9 @@ def metricas_profesor(profesor_id):
             else:
                 metricas['ranking_profesores'] = Profesor.obtener_ranking_profesores()
         
-        return render_template(
-            'informes/metricas_profesor.html', 
-            profesor=profesor, 
+        html = render_template(
+            'informes/metricas_profesor.html',
+            profesor=profesor,
             metricas=metricas if 'metricas_actual' not in metricas else metricas['metricas_actual'],
             metricas_comparacion=metricas.get('metricas_comparacion'),
             comparacion=metricas.get('comparacion'),
@@ -5087,6 +5097,11 @@ def metricas_profesor(profesor_id):
             comparar_meses='comparar' in request.args,  # Indicar si estamos en modo comparación
             error=error  # Pasar el error de validación a la plantilla
         )
+
+        if pdf_requested:
+            pdf = HTML(string=html, base_url=request.base_url).write_pdf()
+            return send_file(io.BytesIO(pdf), download_name=f"metricas_profesor_{profesor_id}.pdf", mimetype='application/pdf')
+        return html
     except Exception as e:
         app.logger.error(f"Error en metricas_profesor: {str(e)}")
         flash(f"Error al cargar métricas del profesor: {str(e)}", "danger")

--- a/app/app.py
+++ b/app/app.py
@@ -3,6 +3,7 @@ import logging
 import traceback
 import re  # para expresiones regulares
 from flask import Flask, render_template, request, redirect, url_for, flash, jsonify, abort, send_file, send_from_directory
+from weasyprint import HTML
 from flask_sqlalchemy import SQLAlchemy
 from datetime import datetime, timedelta, date, time
 from werkzeug.utils import secure_filename
@@ -704,9 +705,16 @@ def informes():
 
 @app.route('/informes/mensual', methods=['GET', 'POST'])
 def informe_mensual():
-    if request.method == 'POST':
-        mes = int(request.form['mes'])
-        anio = int(request.form['anio'])
+    pdf_requested = False
+    if request.method == 'POST' or (request.method == 'GET' and request.args.get('pdf')):
+        if request.method == 'POST':
+            mes = int(request.form['mes'])
+            anio = int(request.form['anio'])
+            pdf_requested = 'pdf' in request.form
+        else:
+            mes = int(request.args.get('mes'))
+            anio = int(request.args.get('anio'))
+            pdf_requested = True
         
         # Obtener el primer y último día del mes
         primer_dia = date(anio, mes, 1)
@@ -895,9 +903,9 @@ def informe_mensual():
         print(f"Total tarde = {division_horario['tarde']}")
         print("===================================================\n")
         
-        return render_template('informes/mensual_resultado.html', 
-                              mes=mes, 
-                              anio=anio, 
+        html = render_template('informes/mensual_resultado.html',
+                              mes=mes,
+                              anio=anio,
                               clases_realizadas=clases_realizadas,
                               clases_no_registradas=clases_no_registradas,
                               conteo_no_registradas=conteo_no_registradas,
@@ -913,8 +921,13 @@ def informe_mensual():
                               total_alumnos=total_alumnos,
                               total_retrasos=total_retrasos,
                               total_pagos=total_pagos)
+
+        if pdf_requested:
+            pdf = HTML(string=html, base_url=request.base_url).write_pdf()
+            return send_file(io.BytesIO(pdf), download_name=f"informe_mensual_{mes}_{anio}.pdf", mimetype='application/pdf')
+        return html
     
-    # Si es GET, mostrar formulario para seleccionar mes y año
+    # Si es GET normal, mostrar formulario para seleccionar mes y año
     mes_actual = datetime.now().month
     anio_actual = datetime.now().year
     return render_template('informes/mensual.html', mes_actual=mes_actual, anio_actual=anio_actual)

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ numpy
 pandas
 matplotlib==3.10.1
 librosa==0.11.0
+WeasyPrint==65.1

--- a/templates/informes/mensual_resultado.html
+++ b/templates/informes/mensual_resultado.html
@@ -640,6 +640,9 @@
                     <button class="btn btn-outline-success" onclick="exportToExcel()">
                         <i class="fas fa-file-excel me-1"></i> Exportar a Excel
                     </button>
+                    <a class="btn btn-outline-danger" href="{{ url_for('informe_mensual', mes=mes, anio=anio, pdf=1) }}">
+                        <i class="fas fa-file-pdf me-1"></i> PDF
+                    </a>
                     <button class="btn btn-outline-primary" onclick="window.print()">
                         <i class="fas fa-print me-1"></i> Imprimir
                     </button>

--- a/templates/informes/metricas_profesor.html
+++ b/templates/informes/metricas_profesor.html
@@ -97,6 +97,9 @@
                         <a href="{{ url_for('informe_mensual') }}" class="btn btn-outline-primary btn-sm w-100">
                             <i class="fas fa-arrow-left me-1"></i> Volver al Informe
                         </a>
+                        <a href="{{ request.path }}?{{ request.query_string.decode() }}{% if request.query_string %}&{% endif %}pdf=1" class="btn btn-outline-danger btn-sm w-100 mt-2">
+                            <i class="fas fa-file-pdf me-1"></i> Exportar PDF
+                        </a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- enable PDF exports via WeasyPrint
- allow monthly reports to be saved as PDF
- allow professor metrics pages to be saved as PDF
- link PDF export buttons in report templates
- update dependencies

## Testing
- `pytest -q` *(fails: unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_e_68418c69547483268c8ef09617ca4c89