### PR TITLE
Add GitHub Actions test workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,23 @@
+name: Run Tests
+
+on:
+  push:
+    branches: [ "**" ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Install test tools
+        run: pip install pytest pytest-cov
+      - name: Run tests
+        run: pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,5 @@ pandas
 matplotlib==3.10.1
 librosa==0.11.0
 WeasyPrint==65.1
+pytest
+pytest-cov


### PR DESCRIPTION
## Summary
- ensure required packages for testing are installed
- add GitHub Actions workflow to run pytest on every push

## Testing
- `pytest -q` *(fails: OperationalError: no such table: profesor)*

------
https://chatgpt.com/codex/tasks/task_e_6841a63975e483268d4868163636a31a